### PR TITLE
Trace decode time of LR_WasmDecoder

### DIFF
--- a/src/wasm/decoder.cc
+++ b/src/wasm/decoder.cc
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include "src/base/platform/elapsed-timer.h"
 #include "src/signature.h"
 
 #include "src/zone-containers.h"
@@ -131,6 +132,10 @@ class LR_WasmDecoder : public Decoder {
 
   TreeResult Decode(FunctionEnv* function_env, const byte* base, const byte* pc,
                     const byte* end) {
+    base::ElapsedTimer decode_timer;
+    if (FLAG_trace_wasm_decode_time) {
+      decode_timer.Start();
+    }
     CHECK(end >= pc);
     trees_.clear();
     stack_.clear();
@@ -157,6 +162,10 @@ class LR_WasmDecoder : public Decoder {
     }
     
     if (ok()) {
+      if (FLAG_trace_wasm_decode_time) {
+        double ms = decode_timer.Elapsed().InMillisecondsF();
+        PrintF(" - decoding took %0.3f ms\n", ms);
+      }
       TRACE("wasm-decode ok\n\n");
     } else {
       TRACE("wasm-error module+%-6d func+%d: %s\n\n", baserel(error_pc_),

--- a/src/wasm/wasm-module.cc
+++ b/src/wasm/wasm-module.cc
@@ -165,7 +165,7 @@ const int kWasmGlobalsArrayBuffer = 3;
 Handle<Code> CompileFunction(ErrorThrower& thrower, Isolate* isolate,
                              ModuleEnv* module_env,
                              const WasmFunction& function, int index) {
-  if (FLAG_trace_wasm_compiler) {
+  if (FLAG_trace_wasm_compiler || FLAG_trace_wasm_decode_time) {
     // TODO(titzer): clean me up a bit.
     OFStream os(stdout);
     os << "Compiling WASM function #" << index << ":";
@@ -425,6 +425,15 @@ class ModuleDecoder : public Decoder {
   // Verifies the body (code) of a given function.
   void VerifyFunctionBody(uint32_t func_num, ModuleEnv* menv,
                           WasmFunction* function) {
+    if (FLAG_trace_wasm_decode_time) {
+      // TODO: clean me up a bit.
+      OFStream os(stdout);
+      os << "Verifying WASM function:";
+      if (function->name_offset > 0) {
+        os << menv->module->GetName(function->name_offset);
+      }
+      os << std::endl;
+    }
     FunctionEnv fenv;
     fenv.module = menv;
     fenv.sig = function->sig;


### PR DESCRIPTION
Adding trace of LR_WasmDecoder decode time.
Also **need to add to v8 repo** FLAG_trace_wasm_decode_time at the same time.