### PR TITLE
Fix segment size check.

### DIFF
--- a/src/wasm/wasm-module.cc
+++ b/src/wasm/wasm-module.cc
@@ -267,8 +267,8 @@ void LoadDataSegments(WasmModule* module, byte* mem_addr, size_t mem_size) {
     if (!segment.init)
       continue;
     CHECK_LT(segment.dest_addr, mem_size);
-    CHECK_LT(segment.source_size, mem_size);
-    CHECK_LT(segment.dest_addr + segment.source_size, mem_size);
+    CHECK_LE(segment.source_size, mem_size);
+    CHECK_LE(segment.dest_addr + segment.source_size, mem_size);
     byte* addr = mem_addr + segment.dest_addr;
     memcpy(addr, module->module_start + segment.source_offset,
            segment.source_size);


### PR DESCRIPTION
Because the checks were less than rather than less than or equal, data segments
could not be positioned at the end of memory.