### PR TITLE
[tf-builder] Added Float64 rounding operations to the tf-builder.

### DIFF
--- a/src/wasm/tf-builder.cc
+++ b/src/wasm/tf-builder.cc
@@ -526,6 +526,16 @@ TFNode* TFBuilder::Unop(WasmOpcode opcode, TFNode* input) {
         return MakeI32Popcnt(input);
       }
     }
+    case kExprF64Floor: {
+      if (m->Float64RoundDown().IsSupported()) {
+        op = m->Float64RoundDown().op();
+        break;
+      } else {
+        op = UnsupportedOpcode(opcode);
+        break;
+      }
+    }
+
 #if WASM_64
     // Opcodes only supported on 64-bit platforms.
     // TODO(titzer): query the machine operator builder here instead of #ifdef.
@@ -1064,7 +1074,7 @@ void TFBuilder::AddThrow(TFNode* exception) {
     Runtime::FunctionId f = Runtime::kThrow;
     const Runtime::Function* fun = Runtime::FunctionForId(f);
     compiler::CallDescriptor* desc =
-      compiler::Linkage::GetRuntimeCallDescriptor(graph->zone(), f, fun->nargs, 
+      compiler::Linkage::GetRuntimeCallDescriptor(graph->zone(), f, fun->nargs,
 						  compiler::Operator::kNoProperties);
     TFNode* inputs[] = {
       graph->CEntryStubConstant(fun->result_size),                     // C entry
@@ -1076,7 +1086,7 @@ void TFBuilder::AddThrow(TFNode* exception) {
       *effect,
       *control
     };
-    
+
     TFNode* node = g->NewNode(graph->common()->Call(desc),
 			      static_cast<int>(arraysize(inputs)), inputs);
     *control = node;

--- a/src/wasm/tf-builder.cc
+++ b/src/wasm/tf-builder.cc
@@ -535,6 +535,33 @@ TFNode* TFBuilder::Unop(WasmOpcode opcode, TFNode* input) {
         break;
       }
     }
+    case kExprF64Ceil: {
+      if (m->Float64RoundUp().IsSupported()) {
+        op = m->Float64RoundUp().op();
+        break;
+      } else {
+        op = UnsupportedOpcode(opcode);
+        break;
+      }
+    }
+    case kExprF64Trunc: {
+      if (m->Float64RoundTruncate().IsSupported()) {
+        op = m->Float64RoundTruncate().op();
+        break;
+      } else {
+        op = UnsupportedOpcode(opcode);
+        break;
+      }
+    }
+    case kExprF64NearestInt: {
+      if (m->Float64RoundTiesEven().IsSupported()) {
+        op = m->Float64RoundTiesEven().op();
+        break;
+      } else {
+        op = UnsupportedOpcode(opcode);
+        break;
+      }
+    }
 
 #if WASM_64
     // Opcodes only supported on 64-bit platforms.

--- a/test/cctest/wasm/test-run-wasm.cc
+++ b/test/cctest/wasm/test-run-wasm.cc
@@ -2384,3 +2384,11 @@ TEST(Run_Wasm_SimpleCallIndirect) {
 }
 
 
+TEST(Run_Wasm_F64Floor) {
+  WasmRunner<double> r(kMachFloat64);
+  BUILD(r, WASM_F64_FLOOR(WASM_GET_LOCAL(0)));
+
+  FOR_FLOAT64_INPUTS(i) {
+    CheckDoubleEq(floor(*i), r.Call(*i));
+  }
+}

--- a/test/cctest/wasm/test-run-wasm.cc
+++ b/test/cctest/wasm/test-run-wasm.cc
@@ -1819,6 +1819,8 @@ TEST(Run_WasmMixedGlobals) {
   USE(unused);
 }
 
+
+#if WASM_64
 // Test the WasmRunner with an Int64 return value and different numbers of
 // Int64 parameters.
 TEST(Run_TestI64WasmRunner) {
@@ -1874,6 +1876,7 @@ TEST(Run_TestI64WasmRunner) {
     }
   }
 }
+#endif
 
 
 TEST(Run_WasmCallEmpty) {
@@ -2390,5 +2393,35 @@ TEST(Run_Wasm_F64Floor) {
 
   FOR_FLOAT64_INPUTS(i) {
     CheckDoubleEq(floor(*i), r.Call(*i));
+  }
+}
+
+
+TEST(Run_Wasm_F64Ceil) {
+  WasmRunner<double> r(kMachFloat64);
+  BUILD(r, WASM_F64_CEIL(WASM_GET_LOCAL(0)));
+
+  FOR_FLOAT64_INPUTS(i) {
+    CheckDoubleEq(ceil(*i), r.Call(*i));
+  }
+}
+
+
+TEST(Run_Wasm_F64Trunc) {
+  WasmRunner<double> r(kMachFloat64);
+  BUILD(r, WASM_F64_TRUNC(WASM_GET_LOCAL(0)));
+
+  FOR_FLOAT64_INPUTS(i) {
+    CheckDoubleEq(trunc(*i), r.Call(*i));
+  }
+}
+
+
+TEST(Run_Wasm_F64NearestInt) {
+  WasmRunner<double> r(kMachFloat64);
+  BUILD(r, WASM_F64_NEARESTINT(WASM_GET_LOCAL(0)));
+
+  FOR_FLOAT64_INPUTS(i) {
+    CheckDoubleEq(nearbyint(*i), r.Call(*i));
   }
 }


### PR DESCRIPTION
Added support for the instructions kExprF64Ceil, kExprF64Floor, kExprF64Trunc, and kExprF64NearestInt in the tf-builder.

Additionally I did some cleanup in test-run-wasm.cc