### PR TITLE
Fixed function calls to wasm functions on arm64.

### DIFF
--- a/src/wasm/wasm-linkage.cc
+++ b/src/wasm/wasm-linkage.cc
@@ -262,7 +262,7 @@ CallDescriptor* ModuleEnv::GetWasmCallDescriptor(Zone* zone,
       compiler::Operator::kNoProperties,  // properties
       kCalleeSaveRegisters,               // callee-saved registers
       kCalleeSaveFPRegisters,             // callee-saved fp regs
-      CallDescriptor::kNoFlags,           // flags
+      CallDescriptor::kUseNativeStack,    // flags
       "c-call");
 }
 }

--- a/test/cctest/wasm/test-run-wasm.cc
+++ b/test/cctest/wasm/test-run-wasm.cc
@@ -2671,6 +2671,7 @@ TEST(Run_TestI64WasmRunner) {
 
 TEST(Run_WasmCallEmpty) {
   const int32_t kExpected = -414444;
+  printf("expected: %x\n", kExpected);
   // Build the target function.
   TestSignatures sigs;
   TestingModule module;

--- a/test/cctest/wasm/test-run-wasm.cc
+++ b/test/cctest/wasm/test-run-wasm.cc
@@ -2671,7 +2671,6 @@ TEST(Run_TestI64WasmRunner) {
 
 TEST(Run_WasmCallEmpty) {
   const int32_t kExpected = -414444;
-  printf("expected: %x\n", kExpected);
   // Build the target function.
   TestSignatures sigs;
   TestingModule module;


### PR DESCRIPTION
V8 used the wrong stack pointer for wasm functions on arm64. The flag kUseNativeStack in the CallDescriptor tells V8 now to use the native stack for wasm functions.